### PR TITLE
Issue/bsd compatibility

### DIFF
--- a/src/CoreArray/dPlatform.cpp
+++ b/src/CoreArray/dPlatform.cpp
@@ -1206,7 +1206,7 @@ C_Int64 CoreArray::SysHandleSeek(TSysHandle Handle, C_Int64 Offset,
 		else
 			return p;
 	#else
-		#if defined(COREARRAY_CYGWIN) || defined(COREARRAY_PLATFORM_MACOS)
+		#if defined(COREARRAY_CYGWIN) || defined(COREARRAY_PLATFORM_MACOS) || defined(COREARRAY_PLATFORM_BSD)
 			return lseek(Handle, Offset, sk);
 		#else
 			return lseek64(Handle, Offset, sk);
@@ -1222,7 +1222,7 @@ bool CoreArray::SysHandleSetSize(TSysHandle Handle, C_Int64 NewSize)
 		else
 			return false;
 	#else
-		#if defined(COREARRAY_CYGWIN) || defined(COREARRAY_PLATFORM_MACOS)
+		#if defined(COREARRAY_CYGWIN) || defined(COREARRAY_PLATFORM_MACOS) || defined(COREARRAY_PLATFORM_BSD)
 			return ftruncate(Handle, NewSize)==0;
 		#else
 			return ftruncate64(Handle, NewSize)==0;

--- a/src/CoreArray/dVLIntGDS.cpp
+++ b/src/CoreArray/dVLIntGDS.cpp
@@ -25,8 +25,8 @@
 // License along with CoreArray.
 // If not, see <http://www.gnu.org/licenses/>.
 
-#include <typeinfo>
 #include "dVLIntGDS.h"
+#include <typeinfo>
 
 
 using namespace std;


### PR DESCRIPTION
This pull request addresses a couple portability issues preventing successful compilation of gdsfmt.

The first should affect all BSDs, which use fseek()/lseek() instead of fseek64()/lseek64().

The second commit affects at least FreeBSD 10.3, which uses the LLVM libc++. In libc++, <typeinfo> includes <cstdint>, which in turn includes <stdint.h>. Since the inclusion of stdint.h is done before the __STDC_LIMIT_MACROS is defined in dType.h, we get a stdint.h without the INT*_MIN/INT*_MAX macros defined, causing a compilation failure.

An alternative workaround that appears to work on this platform is to specify the -std=c++11 option ("By default, Clang builds C++ code according to the C++98 standard..." -- https://clang.llvm.org/cxx_status.html)

I suspect this wouldn't be an issue with the LLVM >= 4.0 libc++, which added its own stdint.h that defines __STDC_LIMIT_MACROS
(https://git.io/vSMy9)